### PR TITLE
feat: PR lifecycle awareness in /bootstrap and /persist

### DIFF
--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -137,7 +137,30 @@ Fetch all open Issues with their last 5 comments in a single GraphQL call:
    gh issue list --state closed --json number,title,milestone,labels,closedAt --limit 50
    ```
 
-No file is written to disk. The GraphQL response is the session's view of project state — held in memory for steps 3 and 4.
+### Open PRs — lifecycle check
+
+Fetch open PRs to detect pending merges:
+
+```bash
+gh pr list --state open --json number,title,headRefName,labels,createdAt,isDraft --limit 50
+```
+
+Cross-reference PRs with Issues:
+- Match via branch naming: regex `/^agent\/(\d+)-/` extracts Issue number from branch `agent/25-foo`
+- Match via PR body: parse `Closes #N` or `Fixes #N`
+- For each PR, classify:
+
+| State | How to detect | Flag |
+|---|---|---|
+| **Fresh** | Created <3 days ago | info only |
+| **Stale** | Created >3 days ago, CI passed | ⚠ yellow — suggest merge |
+| **CI failed** | Last check failed | 🔴 red — suggest diagnosis |
+| **Draft** | `isDraft: true` | info only |
+
+If zero open PRs: skip this section entirely (no visible change to existing flow).
+If GITHUB_MODE=false: skip silently.
+
+No file is written to disk. The GraphQL response and PR list are the session's view of project state — held in memory for steps 3 and 4.
 
 ### Disk structure — ensure Issue directories
 
@@ -241,6 +264,11 @@ Left off at: {Next session: field from last session comment}
 - #N "title" — ready for /delivery (spec complete, no blockers)
 - #N "title" — delivery in progress, N/M deliverables done
 
+[PRs awaiting merge]
+- PR #50 "title" → #49 — opened Nd ago, branch: agent/49-slug
+  ⚠ Stale: open >3 days
+- PR #62 "title" → #N — opened 1d ago (fresh)
+
 [Needs attention]
 - #N "title" — blocked: {reason}
 - #N "title" — stale (Nd since last activity)
@@ -256,6 +284,7 @@ Left off at: {Next session: field from last session comment}
 **Rules for the briefing:**
 - Only show sections that have content (don't show empty sections)
 - "Ready for action" items first — these are what the user can act on
+- "PRs awaiting merge" section only appears when there are open PRs. Omit entirely if zero.
 - Include the *why* for blocked items, not just the status
 - Continuation context is the most valuable line — put it at the top
 - If nothing is in progress, say so: "Clean slate — no active work."

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -150,11 +150,18 @@ Cross-reference PRs with Issues:
 - Match via PR body: parse `Closes #N` or `Fixes #N`
 - For each PR, classify:
 
+For each non-draft PR, check if branch is behind main:
+```bash
+gh pr view $PR_NUMBER --json mergeStateStatus --jq '.mergeStateStatus'
+```
+A `BEHIND` status indicates the branch has diverged from main and needs rebase.
+
 | State | How to detect | Flag |
 |---|---|---|
-| **Fresh** | Created <3 days ago | info only |
+| **Fresh** | Created <3 days ago, not behind | info only |
 | **Stale** | Created >3 days ago, CI passed | ⚠ yellow — suggest merge |
 | **CI failed** | Last check failed | 🔴 red — suggest diagnosis |
+| **Diverged** | `mergeStateStatus: BEHIND` | 🔴 red — suggest rebase |
 | **Draft** | `isDraft: true` | info only |
 
 If zero open PRs: skip this section entirely (no visible change to existing flow).
@@ -265,8 +272,8 @@ Left off at: {Next session: field from last session comment}
 - #N "title" — delivery in progress, N/M deliverables done
 
 [PRs awaiting merge]
-- PR #50 "title" → #49 — opened Nd ago, branch: agent/49-slug
-  ⚠ Stale: open >3 days
+- PR #50 "title" → #49 — opened 5d ago, branch: agent/49-slug
+  ⚠ Stale: open >3 days, branch diverged from main
 - PR #62 "title" → #N — opened 1d ago (fresh)
 
 [Needs attention]

--- a/skills/persist/SKILL.md
+++ b/skills/persist/SKILL.md
@@ -56,8 +56,20 @@ If `git branch -vv` shows `[gone]` entries, present list:
 > "N branches with deleted remote: {list}. Clean up?"
 - If yes: `git branch -d {branch}` for each (use `-D` if `-d` fails).
 
+### Open PRs (if GITHUB_MODE=true)
+```bash
+gh pr list --state open --json number,title,headRefName,createdAt --limit 20
+```
+
+If open PRs exist, surface them:
+> "N open PRs: PR #50 'title' (5d old), PR #62 'title' (1d old). Merge or note in continuation?"
+
+PRs older than 3 days get a ⚠ flag. This is informational — never auto-merge or auto-close.
+
+If GITHUB_MODE=false: skip silently (no error).
+
 ### Skip condition
-If all 4 checks find nothing actionable: output `✓ Repo clean` and proceed to Step 2.
+If all 5 checks find nothing actionable: output `✓ Repo clean` and proceed to Step 2.
 
 ### Error handling
 If any git command fails: skip that check silently, continue with remaining checks.
@@ -75,6 +87,7 @@ Classify what needs persisting:
 | **Milestone signal** | Session advanced a Milestone or revealed something unexpected | Append signal to milestone.md + sync to GitHub |
 | **Memory** | New learning about user, project, or non-obvious feedback | Save/update in `~/.claude/projects/.../memory/` |
 | **Direction** | Product direction decision (thesis, principles, macro architecture) | Suggest to user (don't edit automatically) |
+| **Open PRs** | GITHUB_MODE=true and open PRs exist | Note in session comment continuation context |
 | **Domain drift** | API, auth, schema, or actions code changed but `.claude/docs/` not updated | Alert and suggest domain map update |
 
 **GitHub mode:** If `GITHUB_MODE=true` (see `skills/shared/github-detection.md`), Milestone signal gains GitHub sync and session context is posted as Issue comment (details below).
@@ -102,11 +115,14 @@ gh issue comment $ISSUE_NUMBER --body "$(cat <<'EOF'
 **Decisions:**
 - {decision and rationale}
 
-**Next session:**
-- {concrete next step}
-
 **Key files:**
 - {relevant paths}
+
+**Open PRs:**
+- PR #N "title" (branch, Nd old) — needs merge / CI failed
+
+**Next session:**
+- {concrete next step}
 EOF
 )"
 ```
@@ -114,6 +130,8 @@ EOF
 Rules for the comment content:
 - The `## Session [` prefix is the contract — `/bootstrap` uses it to filter session comments from human comments. Never change this prefix.
 - "What was done": 5-8 bullets max. Details are in commit history. Summarize outcomes, not steps.
+- "Key files": always include relevant paths.
+- "Open PRs": only include if there are open PRs at time of persist. Skip field entirely if zero PRs.
 - "Next session": this is the primary continuation context that next bootstrap will read. Make it specific and actionable.
 - "Decisions": only non-obvious choices that future sessions need to know. Skip if none.
 


### PR DESCRIPTION
## Summary

- Bootstrap fetches open PRs via `gh pr list` during live sync, cross-references with Issues (branch name regex + `Closes #N`), classifies as fresh/stale/CI-failed/diverged/draft
- Bootstrap briefing shows `[PRs awaiting merge]` section with flags when PRs exist
- Persist adds PR check as 5th hygiene step (Step 0) and includes pending PRs in session comment continuation context
- Zero PRs = no visible change; GITHUB_MODE=false = silent skip

## Validation Report — Issue #25

| Criterion | Status | Evidence |
|-----------|--------|----------|
| 1. Bootstrap fetches open PRs | pass | `gh pr list` in Step 2 |
| 2. Cross-references PRs with Issues | pass | Branch regex + `Closes #N` parse |
| 3. Flags stale PRs + diverged branches | pass | Classification table + `mergeStateStatus: BEHIND` check |
| 4. Persist detects open PRs in hygiene | pass | 5th check in Step 0 |
| 5. Persist includes PRs in continuation | pass | `Open PRs:` field in session comment |
| 6. Zero PRs = no change | pass | Skip conditions in both skills |
| 7. GITHUB_MODE=false = silent skip | pass | Explicit skip in both skills |

**Result: 7/7 PASS**

## Test plan

- [ ] Run `/bootstrap` in repo with open PRs — should show `[PRs awaiting merge]` section
- [ ] Run `/bootstrap` in repo with zero PRs — no change to briefing
- [ ] Run `/persist` with open PRs — should surface in hygiene + include in session comment
- [ ] Run `/persist` with GITHUB_MODE=false — should skip PR check silently

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)